### PR TITLE
#50 using Jackson instead of JSON-B

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,28 +29,11 @@
             <groupId>com.selfxdsd</groupId>
             <artifactId>self-api</artifactId>
             <version>${self.core.version}</version>
-            <exclusions> <!--Comes from Yasson JSON-B-->
-                <exclusion>
-                    <groupId>javax.json</groupId>
-                    <artifactId>javax.json-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.selfxdsd</groupId>
             <artifactId>self-core-impl</artifactId>
             <version>${self.core.version}</version>
-            <exclusions> <!--Comes from Yassom JSON-B-->
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>javax.json</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>1.0.7</version>
         </dependency>
         <dependency>
             <groupId>com.selfxdsd</groupId>

--- a/src/main/java/com/selfxdsd/selfweb/api/ProjectManagersApi.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/ProjectManagersApi.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
 import javax.validation.Valid;
 
 /**
@@ -73,9 +72,12 @@ public class ProjectManagersApi extends BaseApiController {
      * Get all the pms working in Self.
      * @return JsonArray.
      */
-    @GetMapping("/managers")
-    public ResponseEntity<JsonArray> managers() {
-        final ResponseEntity<JsonArray> response;
+    @GetMapping(
+        value = "/managers",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> managers() {
+        final ResponseEntity<String> response;
         if(!"admin".equals(this.user.role())) {
             response = ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         } else {
@@ -92,7 +94,7 @@ public class ProjectManagersApi extends BaseApiController {
                 );
             }
             final JsonArray array = builder.build();
-            response = ResponseEntity.ok(array);
+            response = ResponseEntity.ok(array.toString());
         }
         return response;
     }
@@ -106,8 +108,8 @@ public class ProjectManagersApi extends BaseApiController {
         value = "/managers/new",
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<JsonObject> register(@Valid final PmInput newPm) {
-        final ResponseEntity<JsonObject> response;
+    public ResponseEntity<String> register(@Valid final PmInput newPm) {
+        final ResponseEntity<String> response;
         if(!"admin".equals(this.user.role())) {
             response = ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         } else {
@@ -126,6 +128,7 @@ public class ProjectManagersApi extends BaseApiController {
                     .add("username", registered.username())
                     .add("provider", registered.provider().name())
                     .build()
+                    .toString()
             );
         }
         return response;

--- a/src/main/java/com/selfxdsd/selfweb/api/Projects.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/Projects.java
@@ -24,13 +24,13 @@ package com.selfxdsd.selfweb.api;
 
 import com.selfxdsd.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.json.Json;
-import javax.json.JsonObject;
 
 /**
  * Projects.
@@ -61,15 +61,18 @@ public class Projects extends BaseApiController {
      * @param name Simple name of the repo.
      * @return Json response or NO CONTENT if the project is not found.
      */
-    @GetMapping("/projects/github/{owner}/{name}")
-    public ResponseEntity<JsonObject> project(
+    @GetMapping(
+        value = "/projects/github/{owner}/{name}",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> project(
         @PathVariable("owner") final String owner,
         @PathVariable("name") final String name
     ) {
         final Project found = this.core.projects().getProjectById(
             owner + "/" + name, Provider.Names.GITHUB
         );
-        final ResponseEntity<JsonObject> response;
+        final ResponseEntity<String> response;
         if(found == null) {
             response = ResponseEntity.noContent().build();
         } else {
@@ -78,6 +81,7 @@ public class Projects extends BaseApiController {
                     .add("repoFullName", found.repoFullName())
                     .add("provider", found.provider())
                     .build()
+                    .toString()
             );
         }
         return response;

--- a/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
@@ -24,6 +24,7 @@ package com.selfxdsd.selfweb.api;
 
 import com.selfxdsd.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -64,8 +65,11 @@ public class Repositories extends BaseApiController {
      * to which the user has admin rights).
      * @return ResponseEntity.
      */
-    @GetMapping("/repositories/orgs")
-    public ResponseEntity<JsonArray> organizationRepos() {
+    @GetMapping(
+        value = "/repositories/orgs",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> organizationRepos() {
         JsonArrayBuilder reposBuilder = Json.createArrayBuilder();
         final Organizations orgs = this.user
             .provider()
@@ -76,11 +80,11 @@ public class Repositories extends BaseApiController {
             }
         }
         final JsonArray repos = reposBuilder.build();
-        final ResponseEntity<JsonArray> response;
+        final ResponseEntity<String> response;
         if(repos.isEmpty()){
             response = ResponseEntity.noContent().build();
         } else {
-            response = ResponseEntity.ok(repos);
+            response = ResponseEntity.ok(repos.toString());
         }
         return response;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,3 @@
-spring.mvc.converters.preferred-json-mapper=jsonb
-
 spring.security.oauth2.client.registration.github.client-id=${gh_client_id}
 spring.security.oauth2.client.registration.github.client-secret=${gh_client_secret}
 spring.security.oauth2.client.registration.github.scope=repo


### PR DESCRIPTION
Should fix #50 
We now let Spring Boot use Jackson when marshalling/unmarshalling input/output objects. 
However, we still use JSON-P internally, to handle build JsonObjects and JsonArrays.