### PR TITLE
Org Repos Tab #127

### DIFF
--- a/src/main/resources/public/js/getOrgRepos.js
+++ b/src/main/resources/public/js/getOrgRepos.js
@@ -38,7 +38,5 @@ function getOrgRepos() {
  * Wrap a repo's information between <li> tags, with anchor.
  */
 function repoAsTableRow(repo) {
-    return "<tr><td>" +
-        repo.full_name
-        + "</td></tr>"
+    return "<tr><td><a href='/github/" + repo.full_name + "'>" + repo.full_name + "</a></td></tr>"
 }


### PR DESCRIPTION
Fixes #127. Added links to the repos on the Organizations Tab.