### PR TITLE
Mark contributor contract for removal

### DIFF
--- a/src/main/java/com/selfxdsd/selfweb/api/ContributorApi.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/ContributorApi.java
@@ -32,8 +32,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.json.Json;
+
 /**
- * A Contributor.
+ * Contributor endpoints.<br><br>
+ *
+ * These endpoints are mainly used on the 'Contributor Dashboard' page.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
@@ -42,6 +46,9 @@ import org.springframework.web.bind.annotation.*;
  *  display a message saying "You are not a contributor in any project...".
  *  If the /contributor returns data, we should display the Contracts,
  *  links to the Tasks etc.
+ * @todo #142:30min As soon as we have this logic implemented in the core,
+ *  provide a proper implementation for methods markContractForRemoval(...)
+ *  here.
  */
 @RestController
 public class ContributorApi extends BaseApiController {
@@ -198,5 +205,31 @@ public class ContributorApi extends BaseApiController {
             }
         }
         return resp;
+    }
+
+    /**
+     * Mark for removal one contract of the authenticated Contributor.
+     * @param owner Repo owner.
+     * @param name Repo name.
+     * @param role Contributor role (DEV, REV etc).
+     * @return JsonResponse.
+     * @checkstyle ParameterNumber (10 lines)
+     */
+    @DeleteMapping(
+        value = "/contributor/contracts/{owner}/{name}/mark",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> markContractForRemoval(
+        @PathVariable final String owner,
+        @PathVariable final String name,
+        @RequestParam("role") final String role
+    ) {
+        System.out.println("Contract marked for removal!");
+        return ResponseEntity.ok(
+            Json.createObjectBuilder()
+                .add("status", "Contract marked for removal")
+                .build()
+                .toString()
+        );
     }
 }

--- a/src/main/resources/public/js/getAndAddContracts.js
+++ b/src/main/resources/public/js/getAndAddContracts.js
@@ -278,7 +278,7 @@
                                         +"<a href='#' title='Edit Contract' class='editContract'>"
                                         +"<i class='fa fa-edit fa-lg'></i>"
                                         +"</a>  "
-                                        +"<a href='#' title='Remove Contract' class='removeContract'>"
+                                        +"<a href='#' title='Mark Contract For Removal' class='removeContract'>"
                                         +"<i class='fa fa-trash fa-lg'></i>"
                                         +"</a>"
                                     ];

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -61,7 +61,7 @@ function contractAsTableRow(contract) {
         "<td>" + contract.id.role + "</td>"  +
         "<td>" + contract.hourlyRate + "</td>"  +
         "<td>" + contract.value + "</td>" +
-        "<td><a href='#tasks' class='contractAgenda'>" +
+        "<td><a href='#tasks' title='See Tasks & Invoices' class='contractAgenda'>" +
             "<i class='fa fa-laptop fa-lg'></i>" +
         "</a>  "
         +"<a href='#' title='Mark Contract For Removal' class='removeContract'>"

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -20,6 +20,13 @@ function getContributorDashboard() {
                                 getInvoicesOfContract(contract);
                             }
                         );
+                        $($(".removeContract")[$(".removeContract").length -1]).on(
+                            "click",
+                            function(event) {
+                                event.preventDefault();
+                                markContractForRemoval(contract, $(this));
+                            }
+                        );
                     }
                 )
                 if(contributor.contracts.length > 0) {
@@ -329,6 +336,47 @@ function invoiceToPdf(invoice, contract) {
         }
     );
 
+}
+
+/**
+ * Mark a Contract for deletion.
+ * @param contract Contract.
+ * @param removeButton Remove button for which we have to change
+ *  the icon and add the "Restore Contract" listener.
+ */
+function markContractForRemoval(contract, removeButton) {
+    removeButton.off("click");
+    $.ajax(
+        "/api/contributor/contracts/"
+        + contract.id.repoFullName
+        + "/mark?role=" + contract.id.role,
+        {
+            type: "DELETE",
+            success: function() {
+                removeButton.html(
+                    "<i class='fa fa-hourglass' style='color: red;'></i>"
+                );
+                removeButton.attr("title", "Restore the Contract");
+                removeButton.on(
+                    "click",
+                    function(event) {
+                        event.preventDefault();
+                        alert("Contract restored API call!");
+                    }
+                )
+            },
+            error: function () {
+                alert("Something went wrong. Please refresh the page and try again.")
+                removeButton.on(
+                    "click",
+                    function(event) {
+                        event.preventDefault();
+                        markContractForRemoval(contract, removeButton);
+                    }
+                );
+            }
+        }
+    );
 }
 
 /**

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -63,7 +63,11 @@ function contractAsTableRow(contract) {
         "<td>" + contract.value + "</td>" +
         "<td><a href='#tasks' class='contractAgenda'>" +
             "<i class='fa fa-laptop fa-lg'></i>" +
-        "</a></td>" +
+        "</a>  "
+        +"<a href='#' title='Mark Contract For Removal' class='removeContract'>"
+        +"<i class='fa fa-trash fa-lg'></i>"
+        +"</a>"
+        "</td>" +
         "</tr>"
 }
 

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -361,7 +361,7 @@ function markContractForRemoval(contract, removeButton) {
                     "click",
                     function(event) {
                         event.preventDefault();
-                        alert("Contract restored API call!");
+                        alert("Contract restored API call (not yet implemented).");
                     }
                 )
             },

--- a/src/main/resources/templates/contributor.html
+++ b/src/main/resources/templates/contributor.html
@@ -65,7 +65,7 @@
                                                title="Total value of your assigned tasks, active Invoice and PM commission.">
                                             </i>
                                         </th>
-                                        <th>Agenda</th>
+                                        <th>Options</th>
                                     </tr>
                                     </thead>
                                     <tbody>


### PR DESCRIPTION
A Contributor should be able to remove (mark for removal) one of their contracts, from the 'Contributor Dashboard' page.
Front end and backend scaffolding implemented.