### PR TITLE
#160 Confirm on removing a contract from contributor dashboard.

### DIFF
--- a/src/main/resources/public/js/confirmDialog.js
+++ b/src/main/resources/public/js/confirmDialog.js
@@ -42,12 +42,18 @@ var confirmDialog = (function ($) {
         create: function (body, title) {
             return new Promise(function (resolve, reject) {
                 var dialog = getDialogEl();
+                var confirmBtn = dialog.find("#dialog-confirm-btn");
                 dialog.find("#dialog-title").text(title || "Warning");
                 dialog.find("#dialog-body").text(body);
-                dialog.find("#dialog-confirm-btn").click(function(event) {
+                confirmBtn.click(function(event) {
                     dialog.modal("hide");
                     resolve();
-                }); 
+                });
+                //remove all listeners after `hide` is completed
+                dialog.on("hidden.bs.modal", function(){
+                    confirmBtn.off("click")
+                    $(this).off()
+                })
                 dialog.modal("show");
             });
         }

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -24,7 +24,10 @@ function getContributorDashboard() {
                             "click",
                             function(event) {
                                 event.preventDefault();
-                                markContractForRemoval(contract, $(this));
+                                var removeButton = $(this);
+                                confirmDialog
+                                    .create("Are you sure you want to remove this contract?")
+                                    .then(() => markContractForRemoval(contract, removeButton));
                             }
                         );
                     }
@@ -381,7 +384,9 @@ function markContractForRemoval(contract, removeButton) {
                     "click",
                     function(event) {
                         event.preventDefault();
-                        markContractForRemoval(contract, removeButton);
+                        confirmDialog
+                            .create("Are you sure you want to remove this contract?")
+                            .then(() => markContractForRemoval(contract, removeButton));
                     }
                 );
             }

--- a/src/main/resources/templates/contributor.html
+++ b/src/main/resources/templates/contributor.html
@@ -247,6 +247,7 @@
 <footer th:replace="footer.html :: footer"></footer>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.1.1/jspdf.umd.min.js"></script>
 </body>
+<script src="/js/confirmDialog.js"></script>
 <script src="/js/getContributor.js"></script>
 <script>
     $(document).ready(


### PR DESCRIPTION
Closes #160 

- also fixed bug where confirm dialog button click listener was leaking. 