### PR TITLE
Better Revenue Display on Contributor Dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<java.version>11</java.version>
-        <self.core.version>0.0.41-SNAPSHOT</self.core.version>
-        <self.storage.version>0.0.17</self.storage.version>
+        <self.core.version>0.0.41</self.core.version>
+        <self.storage.version>0.0.18</self.storage.version>
     </properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-        <self.core.version>0.0.40</self.core.version>
+        <self.core.version>0.0.41-SNAPSHOT</self.core.version>
         <self.storage.version>0.0.17</self.storage.version>
     </properties>
 

--- a/src/main/java/com/selfxdsd/selfweb/api/input/ContractInput.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/input/ContractInput.java
@@ -52,7 +52,7 @@ public final class ContractInput {
     /**
      * Contributor's role.
      */
-    @Role(oneOf = {"DEV", "REV", "PO", "ARCH"})
+    @Role(oneOf = {"DEV", "REV", "PO", "ARCH", "QA"})
     private String role;
 
     /**

--- a/src/main/java/com/selfxdsd/selfweb/api/output/JsonContract.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/output/JsonContract.java
@@ -35,6 +35,9 @@ public final class JsonContract extends AbstractJsonObject{
             .add("value", NumberFormat
                 .getCurrencyInstance(Locale.GERMANY)
                 .format(contract.value().divide(BigDecimal.valueOf(100))))
+            .add("revenue", NumberFormat
+                .getCurrencyInstance(Locale.GERMANY)
+                .format(contract.revenue().divide(BigDecimal.valueOf(100))))
             .add(
                 "markedForRemoval",
                 String.valueOf(contract.markedForRemoval())

--- a/src/main/java/com/selfxdsd/selfweb/api/output/JsonInvoice.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/output/JsonInvoice.java
@@ -59,6 +59,14 @@ public final class JsonInvoice extends AbstractJsonObject {
                     .add("createdAt", String.valueOf(invoice.createdAt()))
                     .add("isPaid", invoice.isPaid())
                     .add(
+                        "amount",
+                        NumberFormat
+                            .getCurrencyInstance(Locale.GERMANY)
+                            .format(
+                                invoice.amount()
+                                    .divide(BigDecimal.valueOf(100))
+                            )
+                    ).add(
                         "totalAmount",
                         NumberFormat
                             .getCurrencyInstance(Locale.GERMANY)
@@ -66,7 +74,8 @@ public final class JsonInvoice extends AbstractJsonObject {
                                 invoice.totalAmount()
                                     .divide(BigDecimal.valueOf(100))
                             )
-                    ).add(
+                    )
+                    .add(
                         "paymentTime",
                         String.valueOf(invoice.paymentTime())
                     ).add(
@@ -79,6 +88,15 @@ public final class JsonInvoice extends AbstractJsonObject {
                     .add("createdAt", String.valueOf(invoice.createdAt()))
                     .add("isPaid", invoice.isPaid())
                     .add("tasks", new JsonInvoicedTasks(invoice.tasks()))
+                    .add(
+                        "amount",
+                        NumberFormat
+                            .getCurrencyInstance(Locale.GERMANY)
+                            .format(
+                                invoice.amount()
+                                    .divide(BigDecimal.valueOf(100))
+                            )
+                    )
                     .add(
                         "totalAmount",
                         NumberFormat

--- a/src/main/java/com/selfxdsd/selfweb/api/output/JsonTask.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/output/JsonTask.java
@@ -24,6 +24,7 @@ package com.selfxdsd.selfweb.api.output;
 import com.selfxdsd.api.Task;
 
 import javax.json.Json;
+import java.math.BigDecimal;
 
 /**
  * Self Task as JSON.
@@ -44,6 +45,7 @@ public final class JsonTask extends AbstractJsonObject {
                 .add("assignmentDate", String.valueOf(task.assignmentDate()))
                 .add("deadline", String.valueOf(task.deadline()))
                 .add("estimation", task.estimation())
+                .add("value", task.value().divide(BigDecimal.valueOf(100)))
                 .build()
         );
     }

--- a/src/main/resources/public/js/getAndAddContracts.js
+++ b/src/main/resources/public/js/getAndAddContracts.js
@@ -78,6 +78,7 @@
             "<td>" + task.assignmentDate.split('T')[0] + "</td>"  +
             "<td>" + task.deadline.split('T')[0] + "</td>" +
             "<td>" + task.estimation + "min</td>" +
+            "<td>" + task.value + " €</td>" +
             "</tr>"
     }
 

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -158,9 +158,10 @@ function taskAsTableRow(contract, task) {
     }
     return "<tr>" +
         "<td><a href='" + issueLink + "' target='_blank'>#" + task.issueId + "</a></td>" +
-        "<td>" + task.assignmentDate + "</td>"  +
-        "<td>" + task.deadline + "</td>" +
+        "<td>" + task.assignmentDate.split('T')[0] + "</td>"  +
+        "<td>" + task.deadline.split('T')[0] + "</td>" +
         "<td>" + task.estimation + "min</td>" +
+        "<td>" + task.value + " €</td>" +
         "</tr>"
 }
 
@@ -244,7 +245,7 @@ function invoiceAsTableRow(contract, invoice) {
     }
     return "<tr>" +
         "<td>" + invoice.id + "</td>" +
-        "<td>" + invoice.createdAt + "</td>"  +
+        "<td>" + invoice.createdAt.split('T')[0] + "</td>"  +
         "<td>" + invoice.totalAmount + "</td>" +
         "<td>" + status + "</td>" +
         "<td><a href='#' class='downloadInvoice'>" + "<i class='fa fa-file-pdf-o fa-lg'></i>" + "</a></td>" +

--- a/src/main/resources/public/js/getContributor.js
+++ b/src/main/resources/public/js/getContributor.js
@@ -85,7 +85,7 @@ function contractAsTableRow(contract) {
         "<td><a href='" + link + "' target='_blank'>" + contract.id.repoFullName + "</a></td>" +
         "<td>" + contract.id.role + "</td>"  +
         "<td>" + contract.hourlyRate + "</td>"  +
-        "<td>" + contract.value + "</td>" +
+        "<td>" + contract.revenue + "</td>" +
         "<td><a href='#tasks' title='See Tasks & Invoices' class='contractAgenda'>" +
             "<i class='fa fa-laptop fa-lg'></i>" +
         "</a>  "
@@ -246,7 +246,7 @@ function invoiceAsTableRow(contract, invoice) {
     return "<tr>" +
         "<td>" + invoice.id + "</td>" +
         "<td>" + invoice.createdAt.split('T')[0] + "</td>"  +
-        "<td>" + invoice.totalAmount + "</td>" +
+        "<td>" + invoice.amount + "</td>" +
         "<td>" + status + "</td>" +
         "<td><a href='#' class='downloadInvoice'>" + "<i class='fa fa-file-pdf-o fa-lg'></i>" + "</a></td>" +
         "</tr>"

--- a/src/main/resources/templates/contributor.html
+++ b/src/main/resources/templates/contributor.html
@@ -62,7 +62,7 @@
                                                aria-hidden="true"
                                                data-toggle="tooltip"
                                                data-placement="top"
-                                               title="Total value of your assigned tasks, active Invoice and PM commission.">
+                                               title="Total value of your current tasks and active invoice.">
                                             </i>
                                         </th>
                                         <th>Options</th>
@@ -95,6 +95,7 @@
                                             <th>Assigned</th>
                                             <th>Deadline</th>
                                             <th>Estimation</th>
+                                            <th>Value</th>
                                         </tr>
                                         </thead>
                                         <tbody>
@@ -121,7 +122,7 @@
                                         <tr>
                                             <th>ID</th>
                                             <th>Created</th>
-                                            <th>Amount</th>
+                                            <th>Revenue</th>
                                             <th>Status</th>
                                             <th></th>
                                         </tr>

--- a/src/main/resources/templates/project.html
+++ b/src/main/resources/templates/project.html
@@ -333,6 +333,7 @@
                                         <th>Assigned</th>
                                         <th>Deadline</th>
                                         <th>Estimation</th>
+                                        <th>Value</th>
                                     </tr>
                                     </thead>
                                     <tbody>

--- a/src/main/resources/templates/project.html
+++ b/src/main/resources/templates/project.html
@@ -227,6 +227,7 @@
                         </h4>
                     </div>
                     <div class="card-body">
+                        <div>Add a new contributor to your project:</div>
                         <form id="addContractForm">
                             <div class="form-group input-group-sm">
                                 <label for="username">Github Username*</label>
@@ -252,6 +253,7 @@
                                         name="role">
                                     <option selected>DEV</option>
                                     <option>REV</option>
+                                    <option>QA</option>
                                     <option>PO</option>
                                     <option>ARCH</option>
                                 </select>

--- a/src/test/java/com/selfxdsd/selfweb/api/ContractsApiTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/ContractsApiTestCase.java
@@ -114,7 +114,13 @@ public final class ContractsApiTestCase {
                         NumberFormat
                             .getCurrencyInstance(Locale.GERMANY)
                             .format(100)
-                    ).add("markedForRemoval", "null")
+                    ).add(
+                        "revenue",
+                        NumberFormat
+                            .getCurrencyInstance(Locale.GERMANY)
+                            .format(90)
+                    )
+                    .add("markedForRemoval", "null")
                     .build())
                 .build())
         );
@@ -504,6 +510,7 @@ public final class ContractsApiTestCase {
         Mockito.when(contract.project()).thenReturn(project);
         Mockito.when(contract.hourlyRate()).thenReturn(hourlyRate);
         Mockito.when(contract.value()).thenReturn(value);
+        Mockito.when(contract.revenue()).thenReturn(BigDecimal.valueOf(9000));
         return contract;
     }
 

--- a/src/test/java/com/selfxdsd/selfweb/api/ContributorApiTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/ContributorApiTestCase.java
@@ -32,6 +32,7 @@ import org.springframework.http.ResponseEntity;
 
 import javax.json.Json;
 import java.io.StringReader;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -263,6 +264,7 @@ public final class ContributorApiTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(assigned);
         Mockito.when(task.deadline()).thenReturn(assigned.plusDays(10));
         Mockito.when(task.estimation()).thenReturn(estimation);
+        Mockito.when(task.value()).thenReturn(BigDecimal.TEN);
         return task;
     }
 }

--- a/src/test/java/com/selfxdsd/selfweb/api/output/JsonContractTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/output/JsonContractTestCase.java
@@ -61,6 +61,8 @@ public class JsonContractTestCase {
             .thenReturn(BigDecimal.valueOf(5000));
         Mockito.when(contract.value())
             .thenReturn(BigDecimal.valueOf(2000));
+        Mockito.when(contract.revenue())
+            .thenReturn(BigDecimal.valueOf(1800));
         Mockito.when(contract.markedForRemoval())
             .thenReturn(LocalDateTime.now());
     
@@ -96,6 +98,8 @@ public class JsonContractTestCase {
             .thenReturn(BigDecimal.valueOf(5000));
         Mockito.when(contract.value())
             .thenReturn(BigDecimal.valueOf(2000));
+        Mockito.when(contract.revenue())
+            .thenReturn(BigDecimal.valueOf(1800));
         Mockito.when(contract.markedForRemoval())
             .thenReturn(LocalDateTime.now());
         
@@ -130,6 +134,8 @@ public class JsonContractTestCase {
             .thenReturn(BigDecimal.valueOf(5000));
         Mockito.when(contract.value())
             .thenReturn(BigDecimal.valueOf(2000));
+        Mockito.when(contract.revenue())
+            .thenReturn(BigDecimal.valueOf(1800));
         Mockito.when(contract.markedForRemoval())
             .thenReturn(LocalDateTime.now());
         
@@ -143,6 +149,42 @@ public class JsonContractTestCase {
                     .format(20)
             )
         );       
+    }
+
+    /**
+     * JsonContract has revenue.
+     */
+    @Test
+    public void hasRevenue(){
+        final Contract contract = Mockito.mock(Contract.class);
+
+        Id id = Mockito.mock(Id.class);
+
+        Mockito.when(id.getRepoFullName()).thenReturn("Lumi/Test");
+        Mockito.when(id.getContributorUsername()).thenReturn("Lumi3011");
+        Mockito.when(id.getProvider()).thenReturn("Github");
+        Mockito.when(id.getRole()).thenReturn("dev");
+
+        Mockito.when(contract.contractId()).thenReturn(id);
+        Mockito.when(contract.hourlyRate())
+            .thenReturn(BigDecimal.valueOf(5000));
+        Mockito.when(contract.value())
+            .thenReturn(BigDecimal.valueOf(2000));
+        Mockito.when(contract.revenue())
+            .thenReturn(BigDecimal.valueOf(1800));
+        Mockito.when(contract.markedForRemoval())
+            .thenReturn(LocalDateTime.now());
+
+        final JsonObject jsonContract = new JsonContract(contract);
+
+        MatcherAssert.assertThat(
+            jsonContract.getString("revenue"),
+            Matchers.equalTo(
+                NumberFormat
+                    .getCurrencyInstance(Locale.GERMANY)
+                    .format(18)
+            )
+        );
     }
     
     /**
@@ -167,6 +209,8 @@ public class JsonContractTestCase {
             .thenReturn(BigDecimal.valueOf(5000));
         Mockito.when(contract.value())
             .thenReturn(BigDecimal.valueOf(2000));
+        Mockito.when(contract.revenue())
+            .thenReturn(BigDecimal.valueOf(1800));
         Mockito.when(contract.markedForRemoval()).thenReturn(now);
         
         final JsonObject jsonContract = new JsonContract(contract);
@@ -196,6 +240,8 @@ public class JsonContractTestCase {
             .thenReturn(BigDecimal.valueOf(5000));
         Mockito.when(contract.value())
             .thenReturn(BigDecimal.valueOf(2000));
+        Mockito.when(contract.revenue())
+            .thenReturn(BigDecimal.valueOf(1800));
         Mockito.when(contract.markedForRemoval()).thenReturn(null);
         
         final JsonObject jsonContract = new JsonContract(contract);

--- a/src/test/java/com/selfxdsd/selfweb/api/output/JsonTaskTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/output/JsonTaskTestCase.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.json.JsonObject;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -49,6 +50,7 @@ public final class JsonTaskTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(LocalDateTime.now());
         Mockito.when(task.deadline()).thenReturn(LocalDateTime.now());
         Mockito.when(task.estimation()).thenReturn(60);
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
 
         final JsonObject jsonTask = new JsonTask(task);
 
@@ -70,6 +72,7 @@ public final class JsonTaskTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(now);
         Mockito.when(task.deadline()).thenReturn(LocalDateTime.now());
         Mockito.when(task.estimation()).thenReturn(60);
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
 
         final JsonObject jsonTask = new JsonTask(task);
 
@@ -91,7 +94,8 @@ public final class JsonTaskTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(LocalDateTime.now());
         Mockito.when(task.deadline()).thenReturn(now);
         Mockito.when(task.estimation()).thenReturn(60);
-        
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
+
         final JsonObject jsonTask = new JsonTask(task);
         MatcherAssert.assertThat(
             jsonTask.getString("deadline"),
@@ -110,15 +114,35 @@ public final class JsonTaskTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(LocalDateTime.now());
         Mockito.when(task.deadline()).thenReturn(LocalDateTime.now());
         Mockito.when(task.estimation()).thenReturn(60);
-        
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
+
         final JsonObject jsonTask = new JsonTask(task);
         MatcherAssert.assertThat(
             jsonTask.getInt("estimation"),
             Matchers.equalTo(60)
         );
-        
     }
-    
+
+    /**
+     * JsonTask has value.
+     */
+    @Test
+    public void hasValue(){
+        final Task task = Mockito.mock(Task.class);
+        Mockito.when(task.issueId()).thenReturn("123");
+        Mockito.when(task.assignmentDate()).thenReturn(LocalDateTime.now());
+        Mockito.when(task.deadline()).thenReturn(LocalDateTime.now());
+        Mockito.when(task.estimation()).thenReturn(60);
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
+
+        final JsonObject jsonTask = new JsonTask(task);
+        MatcherAssert.assertThat(
+            jsonTask.getInt("value"),
+            Matchers.equalTo(1)
+        );
+    }
+
+
     /**
      * JsonTask hasn't assignmentDate.
      */
@@ -130,6 +154,7 @@ public final class JsonTaskTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(null);
         Mockito.when(task.deadline()).thenReturn(LocalDateTime.now());
         Mockito.when(task.estimation()).thenReturn(60);
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
 
         final JsonObject jsonTask = new JsonTask(task);
 
@@ -150,6 +175,7 @@ public final class JsonTaskTestCase {
         Mockito.when(task.assignmentDate()).thenReturn(LocalDateTime.now());
         Mockito.when(task.deadline()).thenReturn(null);
         Mockito.when(task.estimation()).thenReturn(60);
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(100));
 
         final JsonObject jsonTask = new JsonTask(task);
 


### PR DESCRIPTION
On the Contributor Dashboard we now display only the ammounts which they are going to receive (without PM commission, since it's not their business).

Added JsonInvoice.amount and JsonContract.revenue.
Added value column for Tasks tables. 
Updated self-core to 0.0.41 and self-storage to 0.0.18.
Some other small changes.