### PR TITLE
#305 don't show PaymentMethods in JsonProject

### DIFF
--- a/src/main/java/com/selfxdsd/selfweb/api/output/JsonProject.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/output/JsonProject.java
@@ -48,8 +48,10 @@ public final class JsonProject extends AbstractJsonObject {
                     "manager",
                     new JsonProjectManager(project.projectManager())
                 )
-                .add("wallet", new JsonWallet(project.wallet()))
-                .build()
+                .add(
+                    "wallet",
+                    new JsonWallet(project.wallet(), Boolean.FALSE)
+                ).build()
         );
     }
 }

--- a/src/test/java/com/selfxdsd/selfweb/api/output/JsonProjectTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/output/JsonProjectTestCase.java
@@ -320,7 +320,7 @@ public final class JsonProjectTestCase {
                 .add(
                     "available",
                     wallet.available().divide(BigDecimal.valueOf(100))
-                ).add("paymentMethods", Json.createArrayBuilder()).build())
+                ).build())
         );       
     }
    


### PR DESCRIPTION
Fixes #305 

We don't show the wallet's payment methods in JsonProject, because this slows the response time a lot when there are multiple Stripe PaymentMethods registered.