### PR TITLE
#308 Contract hourly rate rounded up

### DIFF
--- a/src/main/java/com/selfxdsd/selfweb/api/ContractsApi.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/ContractsApi.java
@@ -43,6 +43,7 @@ import javax.validation.constraints.Min;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.NumberFormat;
@@ -335,8 +336,10 @@ public class ContractsApi extends BaseApiController {
 
         final String repoFullName = owner + "/" + name;
         final String provider = this.user.provider().name();
+
         final BigDecimal hourlyRate = BigDecimal
             .valueOf(input.getHourlyRate())
+            .setScale(2, RoundingMode.HALF_UP)
             .multiply(BigDecimal.valueOf(100));
 
         ResponseEntity<String> response;
@@ -420,6 +423,7 @@ public class ContractsApi extends BaseApiController {
                 final Contract updated = contract.update(
                     BigDecimal
                         .valueOf(newHourlyRate)
+                        .setScale(2, RoundingMode.HALF_UP)
                         .multiply(BigDecimal.valueOf(100))
                 );
                 resp = ResponseEntity.ok(

--- a/src/test/java/com/selfxdsd/selfweb/api/ContractsApiTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/ContractsApiTestCase.java
@@ -195,14 +195,20 @@ public final class ContractsApiTestCase {
 
         final ContractInput input = new ContractInput();
         input.setUsername("john");
-        input.setHourlyRate(10);
+        input.setHourlyRate(16.33);
         input.setRole(Contract.Roles.DEV);
 
         MatcherAssert.assertThat(api
                 .contracts("mihai", "test", input).getStatusCode(),
             Matchers.is(HttpStatus.CREATED));
-        Mockito.verify(contracts).addContract("mihai/test",
-            "john", "github", BigDecimal.valueOf(10.0 * 100), "DEV");
+        Mockito.verify(contracts)
+            .addContract(
+                "mihai/test",
+                "john",
+                "github",
+                BigDecimal.valueOf(1633).setScale(2),
+                "DEV"
+            );
     }
 
     /**


### PR DESCRIPTION
Fixes #308 

Input contract hourly rate (for create or update) is rounded (half up) to 2 decimals before being multiplied by 100. Thus, the resulting BigDecimal will always be an integer representing the cents.

User input: 16.44 => 1644 cents; 16.4435 => 1644 cents; 16.4451 => 1645 cents.
