### PR TITLE
#258 Improvements for table pagination, search input and filters.

### DIFF
--- a/src/main/resources/public/css/main.css
+++ b/src/main/resources/public/css/main.css
@@ -160,3 +160,53 @@ body {
     pointer-events: none;
     z-index: 2000;   
 }
+
+/*Tables footer customization. */
+[id$=_paginate].dataTables_paginate {
+    padding: 0 !important;
+    align-items: center !important;
+    justify-content: center !important;
+    display: flex !important;
+    float: right !important;
+    margin-top: 4px;
+}
+
+[id$=_paginate] > a.paginate_button {
+    padding: 0 !important;
+    height: 2.5em !important;
+    width: 2.5em !important;
+    display: inline-flex  !important;
+    align-items: center  !important;
+    justify-content: center  !important;
+}
+
+[id$=_paginate] > span .paginate_button {
+    padding: 0px !important;
+    height: 2.5em !important;
+    width: 2.5em !important;
+    display: inline-flex  !important;
+    align-items: center  !important;
+    justify-content: center  !important;
+}
+
+[id$=_length]{
+    margin: 0 !important;
+    margin-left: 8px !important;
+    padding: 0 !important;
+    height: 100% !important;
+}
+
+[id$=_length] > label {
+    display: inline-flex !important;
+    flex-direction: column;
+    align-items: center !important;
+    justify-content: center !important;
+    font-size: 14px !important;
+    font-weight: normal !important;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+.dataTables_info {
+    text-align: center;
+}

--- a/src/main/resources/public/js/getAndAddContracts.js
+++ b/src/main/resources/public/js/getAndAddContracts.js
@@ -14,6 +14,8 @@
 * @todo #253:60min On frontend, in Contracts tab, after adding a new contract, we should add the new
 *  contract to contract table, instead of updating table by re-fetching all contracts again.
 *  Same logic should be applied to "markContractForRemove" and "restoreContract".
+* @todo #258:60min Investigate why `date` filtering using `Search builder` plugin is not
+*  working on column `created` of table `invoices` (`#invoicesTable`).
 */
 var projectContractsCount = -1;
 (function getAndAddContracts($, contractsService, usersService, confirmDialog){
@@ -26,8 +28,26 @@ var projectContractsCount = -1;
         )
         $("#tasks").show();
         $("#tasksTable").DataTable({
+            dom: "<'row w-100 align-items-center'<'col-sm-12 col-md-12 justify-content-end'Q>>" +
+            "<'row w-100'<'col-sm-12'tr>>" +
+            "<'row w-100 align-items-center'<'col-sm-12 col-md-4 justify-content-end mb-1'i><'col-sm-12 col-md-8 d-flex justify-content-end align-items-center'lp>>",
+            searchBuilder: {
+                columns: [1, 2],
+            },
             language: {
-                loadingRecords: '<img src="/images/loading.svg" height="100">'
+                loadingRecords: '<img src="/images/loading.svg" height="100">',
+                searchBuilder:{
+                    add: "+",
+                    title: {
+                        0: 'Date filters',
+                        _: 'Date filters (%d)'
+                    },
+                },
+                lengthMenu: "<div style='margin-bottom: 2px'>Show entries</div><div>_MENU_</div>",
+                paginate: {
+                    next: "<i class='fa fa-fw fa-chevron-right'></i>",
+                    previous: "<i class='fa fa-fw fa-chevron-left'></i>"
+                },
             },
             ajax: {
                 url: "/api/projects/"
@@ -58,10 +78,12 @@ var projectContractsCount = -1;
                 },
                 {
                     data: "assignmentDate",
+                    type: 'date',
                     render: (data) => data.split('T')[0]
                 },
                 {
                     data: "deadline",
+                    type: 'date',
                     render: (data) => data.split('T')[0]
                 },
                 {
@@ -84,9 +106,32 @@ var projectContractsCount = -1;
         )
         $("#invoices").show();
         $("#invoicesTable").DataTable({
-            language: {
-                loadingRecords: '<img src="/images/loading.svg" height="100">'
+            searching: false,
+            dom: "<'row w-100 align-items-center'<'col-sm-12 col-md-12 justify-content-end'Q>>" +
+            "<'row w-100'<'col-sm-12'tr>>" +
+            "<'row w-100 align-items-center'<'col-sm-12 col-md-4 justify-content-end mb-1'i><'col-sm-12 col-md-8 d-flex justify-content-end align-items-center'lp>>",
+            searchBuilder: {
+                columns: [1],
             },
+            language: {
+                loadingRecords: '<img src="/images/loading.svg" height="100">',
+                lengthMenu: "<div style='margin-bottom: 2px'>Show entries</div><div>_MENU_</div>",
+                paginate: {
+                    next: "<i class='fa fa-fw fa-chevron-right'></i>",
+                    previous: "<i class='fa fa-fw fa-chevron-left'></i>"
+                },
+                searchBuilder:{
+                    add: "+",
+                    title: {
+                        0: 'Date filters',
+                        _: 'Date filters (%d)'
+                    },
+                },
+            },
+            columnDefs: [
+                { targets: [4], orderable: false },
+                { targets: 1, type: 'date'}
+            ],
             ajax: function(data, callback){
                 $.ajax(
                     "/api/projects/"
@@ -249,9 +294,23 @@ var projectContractsCount = -1;
         function loadContracts() {
             $("#contracts").dataTable().fnDestroy();
             $("#contracts").dataTable({
+                dom: "<'row w-100 align-items-center'<'col-sm-12 col-md-12 justify-content-end'f>>" +
+                "<'row w-100'<'col-sm-12'tr>>" +
+                "<'row w-100 align-items-center mt-1'<'col-sm-12 col-md-4 justify-content-end mb-1'i><'col-sm-12 col-md-8 d-flex justify-content-end align-items-center'lp>>",
                 language: {
-                    loadingRecords: '<img src="/images/loading.svg" height="100">'
+                    loadingRecords: '<img src="/images/loading.svg" height="100">',
+                    lengthMenu: "<div style='margin-bottom: 2px'>Show entries</div><div>_MENU_</div>",
+                    paginate: {
+                        next: "<i class='fa fa-fw fa-chevron-right'></i>",
+                        previous: "<i class='fa fa-fw fa-chevron-left'></i>"
+                    },
+                    searchPlaceholder: " Contributor..."
                 },
+                "columnDefs": [
+                    { "targets": [0], "searchable": true },
+                    { "targets": [1, 2, 3, 4], "searchable": false },
+                    { "targets": [4], "orderable": false }
+                ],
                 ajax: function(data, callback){
                     contractsService
                     .getAll(project)

--- a/src/main/resources/templates/head.html
+++ b/src/main/resources/templates/head.html
@@ -11,10 +11,12 @@
     <link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/1.0.1/css/searchBuilder.dataTables.min.css"/>
 
     <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.6.2/js/dataTables.buttons.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.0.1/js/dataTables.searchBuilder.min.js"></script>
     <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.bundle.min.js "></script>
     <script type="text/javascript" src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
     <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>


### PR DESCRIPTION
closes #258 

- moved "Show entries per page" before the pagination
- tweaks on pagination ux (smaller buttons, icons for next/previous page).
- project contributors can be searched only by "Contributor"  and search input has placeholder now.
- "options" column in "Contracts" can't be ordered anymore.
![contracts_table](https://user-images.githubusercontent.com/10284893/103475760-bfac6680-4db8-11eb-8270-34eb73245e3b.png)

-  used datatables `Search Builder` plugin to filter dates (`assigned` and `deadline`) in "Tasks" table and `created` in "Invoices" table.
![date_filter](https://user-images.githubusercontent.com/10284893/103475771-d783ea80-4db8-11eb-99bd-ea845fcba290.png)


---
since is the last day before this puzzle deadline, left puzzle to fix `created` date filtering in  "Invoices", somehow is not working... 

