### PR TITLE
#340 Managed Repos Tab Implemented

### DIFF
--- a/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
@@ -88,4 +88,32 @@ public class Repositories extends BaseApiController {
         }
         return response;
     }
+
+    /**
+     * Get the User's Projects (repos managed by Self XDSD).
+     * @return ResponseEntity.
+     */
+    @GetMapping(
+        value = "/repositories/managed",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> managedRepos() {
+        JsonArrayBuilder reposBuilder = Json.createArrayBuilder();
+        for(final Project project : this.user.projects()) {
+            reposBuilder = reposBuilder.add(
+                Json.createObjectBuilder()
+                    .add("repoFullName", project.repoFullName())
+                    .add("provider", project.provider())
+                    .build()
+            );
+        }
+        final JsonArray repos = reposBuilder.build();
+        final ResponseEntity<String> response;
+        if(repos.isEmpty()){
+            response = ResponseEntity.noContent().build();
+        } else {
+            response = ResponseEntity.ok(repos.toString());
+        }
+        return response;
+    }
 }

--- a/src/main/resources/public/js/getManagedRepos.js
+++ b/src/main/resources/public/js/getManagedRepos.js
@@ -1,0 +1,49 @@
+$(document).ready(
+    function () {
+        getManagedRepos();
+    }
+);
+
+function projectAsTableRow(project) {
+    var href;
+    if(project.provider == 'github') {
+        href="/github/" + project.repoFullName;
+    } else if (project.provider == 'gitlab') {
+        href="/gitlab/" + project.repoFullName;
+    } else {
+        href="#";
+    }
+    return [
+        "<a href=" + href + ">" + project.repoFullName + "</a>"
+    ]
+}
+
+/**
+ * Get the authenticated user's Projects.
+ */
+function getManagedRepos() {
+    $("#managedReposTable").dataTable({
+        language: {
+            loadingRecords: '<img src="/images/loading.svg" height="100">',
+            emptyTable: "Seems like you don't have any repos managed by Self XDSD.<br> Go to one of the tabs on the right and activate your first repository!"
+        },
+        ajax: function (_data, callback) {
+            $.ajax("/api/repositories/managed", {
+                type: "GET",
+                statusCode: {
+                    200: function (projects) {
+                        callback({ data: projects.map(projectAsTableRow) });
+                    },
+                    204: function () {
+                        callback({ data: [] });
+                    }
+                }
+            });
+        },
+        drawCallback:function(){
+            $('[data-toggle="tooltip"]').tooltip({
+                boundary: 'window'
+            });
+        }
+    });
+}

--- a/src/main/resources/templates/repositories.html
+++ b/src/main/resources/templates/repositories.html
@@ -20,7 +20,10 @@
             <div class="card-footer">
                 <ul class="nav nav-tabs card-header-tabs">
                     <li class="nav-item">
-                        <button class="nav-link active" role="button" id="personalReposButton">Personal Repos</button>
+                        <button class="nav-link active" role="button" id="managedReposButton">Managed Repos</button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link" role="button" id="personalReposButton">Personal Repos</button>
                     </li>
                     <li class="nav-item">
                         <button class="nav-link" role="button" id="orgReposButton">Organization Repos</button>
@@ -29,7 +32,27 @@
             </div>
         </div>
     </header>
-        <div class="collapse multi-collapse show" id="personalRepos">
+    <div class="collapse multi-collapse show" id="managedRepos">
+        <div class="card card-body">
+            <div class="table-responsive">
+                <div id="managedReposTable_wrapper" class="dataTables_wrapper dt-bootstrap4">
+                    <div id="managed-repos-info" class="mb-4">
+                        These are all your repositories which are managed by Self XDSD.
+                    </div>
+                    <table id="managedReposTable" class="display">
+                        <thead>
+                        <tr>
+                            <th></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="collapse multi-collapse" id="personalRepos">
             <div class="card card-body">
                 <div class="table-responsive">
                     <div id="reposTable_wrapper" class="dataTables_wrapper dt-bootstrap4">
@@ -52,7 +75,7 @@
                 </div>
             </div>
         </div>
-        <div class="collapse multi-collapse" id="orgRepos">
+    <div class="collapse multi-collapse" id="orgRepos">
             <div class="card card-body">
                 <div class="table-responsive">
                     <div id="orgReposTable_wrapper" class="dataTables_wrapper dt-bootstrap4">
@@ -82,6 +105,7 @@
 </main>
 <footer th:replace="footer.html :: footer"></footer>
 </body>
+<script src="/js/getManagedRepos.js"></script>
 <script src="/js/getPublicRepos.js"></script>
 <script src="/js/getOrgRepos.js"></script>
 <script>
@@ -89,12 +113,27 @@
         function () {
             $("#reposHeaderLink").addClass("active");
 
+            $("#managedReposButton").on(
+                "click",
+                function(){
+                    $(this).addClass("active");
+                    $("#managedRepos").addClass("show");
+
+                    $("#personalReposButton").removeClass("active");
+                    $("#personalRepos").removeClass("show");
+                    $("#orgReposButton").removeClass("active");
+                    $("#orgRepos").removeClass("show");
+                }
+            );
+
             $("#personalReposButton").on(
                 "click",
                 function(){
                     $(this).addClass("active");
                     $("#personalRepos").addClass("show");
 
+                    $("#managedReposButton").removeClass("active");
+                    $("#managedRepos").removeClass("show");
                     $("#orgReposButton").removeClass("active");
                     $("#orgRepos").removeClass("show");
                 }
@@ -106,6 +145,8 @@
                     $(this).addClass("active");
                     $("#orgRepos").addClass("show");
 
+                    $("#managedReposButton").removeClass("active");
+                    $("#managedRepos").removeClass("show");
                     $("#personalReposButton").removeClass("active");
                     $("#personalRepos").removeClass("show");
                 }

--- a/src/test/java/com/selfxdsd/selfweb/api/RepositoriesTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/RepositoriesTestCase.java
@@ -31,6 +31,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +42,7 @@ import java.util.List;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle ExecutableStatementCount (500 lines)
  */
 public final class RepositoriesTestCase {
 
@@ -97,6 +100,75 @@ public final class RepositoriesTestCase {
         MatcherAssert.assertThat(
             Json.createReader(new StringReader(resp.getBody())).readArray(),
             Matchers.iterableWithSize(1)
+        );
+    }
+
+    /**
+     * The managedRepos endpoint returns NO CONTENT if the User has no
+     * Projects.
+     */
+    @Test
+    public void returnsNoContentManagedRepos() {
+        final Projects owned = Mockito.mock(Projects.class);
+        Mockito.when(owned.iterator()).thenReturn(
+            new ArrayList<Project>().iterator()
+        );
+        final User user = Mockito.mock(User.class);
+        Mockito.when(user.projects()).thenReturn(owned);
+        MatcherAssert.assertThat(
+            new Repositories(user).managedRepos().getStatusCode(),
+            Matchers.equalTo(HttpStatus.NO_CONTENT)
+        );
+    }
+
+    /**
+     * It can return the user's manager repos.
+     */
+    @Test
+    public void returnsManagedRepos() {
+        final Project first = Mockito.mock(Project.class);
+        Mockito.when(first.repoFullName()).thenReturn("mihai/test");
+        Mockito.when(first.provider()).thenReturn("github");
+        final Project second = Mockito.mock(Project.class);
+        Mockito.when(second.repoFullName()).thenReturn("mihai/test2");
+        Mockito.when(second.provider()).thenReturn("github");
+
+        final Projects owned = Mockito.mock(Projects.class);
+        Mockito.when(owned.iterator()).thenReturn(
+            List.of(first, second).iterator()
+        );
+        final User user = Mockito.mock(User.class);
+        Mockito.when(user.projects()).thenReturn(owned);
+        final ResponseEntity<String> resp = new Repositories(user)
+            .managedRepos();
+        MatcherAssert.assertThat(
+            resp.getStatusCode(),
+            Matchers.equalTo(HttpStatus.OK)
+        );
+        final JsonArray array = Json.createReader(
+            new StringReader(resp.getBody())
+        ).readArray();
+        MatcherAssert.assertThat(
+            array,
+            Matchers.iterableWithSize(2)
+        );
+        final JsonObject firstJson = (JsonObject) array.get(0);
+        MatcherAssert.assertThat(
+            firstJson.getString("repoFullName"),
+            Matchers.equalTo("mihai/test")
+        );
+        MatcherAssert.assertThat(
+            firstJson.getString("provider"),
+            Matchers.equalTo("github")
+        );
+        final JsonObject secondJson = (JsonObject) array.get(1);
+        MatcherAssert.assertThat(
+            secondJson.getString("repoFullName"),
+            Matchers.equalTo("mihai/test2")
+        );
+        MatcherAssert.assertThat(
+            secondJson.getString("provider"),
+            Matchers.equalTo("github")
         );
     }
 


### PR DESCRIPTION
Fixes #340 

Implemented and tested Repositories.managedRepos() backend;
Implemented `Managed Repos` tab on the Repositories page.

![managed_repos](https://user-images.githubusercontent.com/6305156/104904645-105fba00-598a-11eb-9929-26fd75fbc385.png)
