### PR TITLE
#356 Cookies Banner/Settings Added

### DIFF
--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -42,7 +42,7 @@
             <li>
               <a href="#">Data & Privacy Policy</a>
             </li>
-            <li>
+            <li th:unless="${testEnvironment}">
               <a href="javascript:cookieConsent.changeConsent();">Cookies Settings</a>
             </li>
           </ul>

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -42,10 +42,33 @@
             <li>
               <a href="#">Data & Privacy Policy</a>
             </li>
+            <li>
+              <a href="javascript:cookieConsent.changeConsent();">Cookies Settings</a>
+            </li>
           </ul>
         </div>
       </div>
     </div>
     <div class="footer-copyright text-center py-3 bg-light">Copyright © Self XDSD Team</div>
+    <script th:unless="${testEnvironment}" src="//www.eucookie.eu/public/gdpr-cookie-consent.js" type="text/javascript"></script>
+    <script th:unless="${testEnvironment}" type="text/javascript">
+      var cookieConsent = new cookieConsent({
+        clientId: '7a1fc21f-8fa6-44f2-90f3-84ff0ae35e90',
+        position: 'bottomLeft',
+        backgroundColor: '#f8f9fa',
+        fontColor: '#24292e',
+        linkColor: '#701516',
+        buttonBackground: '#701516'
+      });
+      cookieConsent.run();
+    </script>
+    <script th:unless="${testEnvironment}" data-cookie-if="analytical" async type="text/plain" src="https://www.googletagmanager.com/gtag/js?id=G-5F9Q5Y4G8P"></script>
+    <script th:unless="${testEnvironment}" data-cookie-if="analytical" type="text/plain">
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-5F9Q5Y4G8P');
+    </script>
   </footer>
 </html>

--- a/src/main/resources/templates/head.html
+++ b/src/main/resources/templates/head.html
@@ -150,13 +150,5 @@
                 return this.charAt(0).toUpperCase() + this.slice(1);
             }
     </script>
-    <script th:unless="${testEnvironment}" async src="https://www.googletagmanager.com/gtag/js?id=G-5F9Q5Y4G8P"></script>
-    <script th:unless="${testEnvironment}">
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'G-5F9Q5Y4G8P');
-    </script>
 </head>
 </html>


### PR DESCRIPTION
Fixes #356

Added Cookies Settings. The user can opt in/out of Analytics, Social and Marketing cookies.
The banned appears on the bottom left side of the page and uses the same colors as the overall webside.

<img width="988" alt="Screenshot 2021-02-06 at 21 38 57" src="https://user-images.githubusercontent.com/6305156/107128159-129ba100-68c4-11eb-95c4-e51ffab60d59.png">
