### PR TITLE
#364 Tax ID label -> VAT Number

### DIFF
--- a/src/main/resources/templates/contributor.html
+++ b/src/main/resources/templates/contributor.html
@@ -250,10 +250,10 @@
                         </div>
                     </div>
                     <div class="form-group input-group-sm">
-                        <label for="taxId">Tax ID</label>
+                        <label for="taxId">VAT Number</label>
                         <input type="text" class="form-control" id="taxId" name="taxId" placeholder="e.g. VAT number" autocomplete="off">
                         <div class="invalid-feedback taxId-error">
-                            Please specify a valid tax ID.
+                            Please specify a valid VAT numberF.
                         </div>
                     </div>
                     <div class="form-group input-group-sm">

--- a/src/main/resources/templates/project.html
+++ b/src/main/resources/templates/project.html
@@ -667,10 +667,10 @@
                                 </div>
                             </div>
                             <div class="form-group input-group-sm">
-                                <label for="taxId">Tax ID</label>
+                                <label for="taxId">VAT Number</label>
                                 <input type="text" class="form-control" id="taxId" name="taxId" placeholder="e.g. VAT number" autocomplete="off">
                                 <div class="invalid-feedback taxId-error">
-                                    Please specify a valid tax ID.
+                                    Please specify a valid VAT number.
                                 </div>
                             </div>
                             <div class="form-group input-group-sm">


### PR DESCRIPTION
Fixes #364 

Renamed the field's label and error message from "Tax ID" to "VAT Number".