### PR TITLE
#443 Backend for Personal Repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<java.version>11</java.version>
-        <self.core.version>0.0.81</self.core.version>
-        <self.storage.version>0.0.70</self.storage.version>
+        <self.core.version>0.0.88</self.core.version>
+        <self.storage.version>0.0.71</self.storage.version>
     </properties>
 
 	<dependencies>

--- a/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
@@ -61,6 +61,33 @@ public class Repositories extends BaseApiController {
     }
 
     /**
+     * Get the user's personal repos (both public and private).
+     * @return ResponseEntity.
+     */
+    @GetMapping(
+        value = "/repositories/personal",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> personalRepos() {
+        JsonArrayBuilder reposBuilder = Json.createArrayBuilder();
+        final Repos personal = this.user.provider().repos();
+        for(final Repo repo : personal) {
+            reposBuilder = reposBuilder.add(Json.createObjectBuilder()
+                .add("repoFullName", repo.fullName())
+                .add("provider", repo.provider())
+                .build());
+        }
+        final JsonArray repos = reposBuilder.build();
+        final ResponseEntity<String> response;
+        if(repos.isEmpty()){
+            response = ResponseEntity.noContent().build();
+        } else {
+            response = ResponseEntity.ok(repos.toString());
+        }
+        return response;
+    }
+
+    /**
      * Get the user's organization repos (repos in an organization
      * to which the user has admin rights).
      * @return ResponseEntity.

--- a/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
@@ -38,10 +38,6 @@ import javax.json.JsonArrayBuilder;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #33:60min Design the front-end part, similarly to how
- *  we already read and display the public repos. Don't forget to
- *  add a tooltip advising the user to go to Github Settings and
- *  grant Org Access if they do not see all the repos.
  */
 @RestController
 public class Repositories extends BaseApiController {

--- a/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
+++ b/src/main/java/com/selfxdsd/selfweb/api/Repositories.java
@@ -59,6 +59,8 @@ public class Repositories extends BaseApiController {
     /**
      * Get the user's personal repos (both public and private).
      * @return ResponseEntity.
+     * @todo #443:60min Modify the front-end part of personal repos. We
+     *  should call this endpoint instead of Github directly.
      */
     @GetMapping(
         value = "/repositories/personal",

--- a/src/main/resources/templates/repositories.html
+++ b/src/main/resources/templates/repositories.html
@@ -60,7 +60,7 @@
                             <img src="/images/loading.svg">
                         </div>
                         <div id="personal-repos-info" class="mb-4" style="display: none;">
-                            These are all your personal public repositories (personal private repositories are not yet supported).
+                            These are all your personal repositories, both public and private.
                         </div>
                         <table id="repos" class="display">
                             <thead>

--- a/src/test/java/com/selfxdsd/selfweb/api/RepositoriesTestCase.java
+++ b/src/test/java/com/selfxdsd/selfweb/api/RepositoriesTestCase.java
@@ -181,4 +181,79 @@ public final class RepositoriesTestCase {
         );
     }
 
+    /**
+     * It can return the user's personal repos.
+     */
+    @Test
+    public void returnsFoundPersonalRepos() {
+        final Repo first = Mockito.mock(Repo.class);
+        Mockito.when(first.fullName()).thenReturn("mihai/first");
+        Mockito.when(first.provider()).thenReturn("github");
+
+        final Repo second = Mockito.mock(Repo.class);
+        Mockito.when(second.fullName()).thenReturn("mihai/second");
+        Mockito.when(second.provider()).thenReturn("github");
+
+
+        final Repos personal = Mockito.mock(Repos.class);
+        Mockito.when(personal.iterator()).thenReturn(
+            List.of(first, second).iterator()
+        );
+        final Provider provider = Mockito.mock(Provider.class);
+        Mockito.when(provider.repos()).thenReturn(personal);
+        final User user = Mockito.mock(User.class);
+        Mockito.when(user.provider()).thenReturn(provider);
+
+        final Repositories reposApi = new Repositories(user);
+        final ResponseEntity<String> resp = reposApi.personalRepos();
+        MatcherAssert.assertThat(
+            resp.getStatusCode(),
+            Matchers.equalTo(HttpStatus.OK)
+        );
+        final JsonArray array = Json
+            .createReader(new StringReader(resp.getBody()))
+            .readArray();
+        MatcherAssert.assertThat(array, Matchers.iterableWithSize(2));
+        MatcherAssert.assertThat(array.get(0)
+                .asJsonObject()
+                .getString("repoFullName"),
+            Matchers.equalTo("mihai/first")
+        );
+        MatcherAssert.assertThat(array.get(0)
+                .asJsonObject()
+                .getString("provider"),
+            Matchers.equalTo("github")
+        );
+        MatcherAssert.assertThat(array.get(1)
+                .asJsonObject()
+                .getString("repoFullName"),
+            Matchers.equalTo("mihai/second")
+        );
+        MatcherAssert.assertThat(array.get(1)
+                .asJsonObject()
+                .getString("provider"),
+            Matchers.equalTo("github")
+        );
+    }
+
+    /**
+     * If the user has no personal repos, it should return NO CONTENT.
+     */
+    @Test
+    public void returnsNoContentPersonalRepos() {
+        final Repos personal = Mockito.mock(Repos.class);
+        Mockito.when(personal.iterator()).thenReturn(
+            new ArrayList<Repo>().iterator()
+        );
+        final Provider provider = Mockito.mock(Provider.class);
+        Mockito.when(provider.repos()).thenReturn(personal);
+        final User user = Mockito.mock(User.class);
+        Mockito.when(user.provider()).thenReturn(provider);
+
+        final Repositories reposApi = new Repositories(user);
+        MatcherAssert.assertThat(
+            reposApi.personalRepos().getStatusCode(),
+            Matchers.equalTo(HttpStatus.NO_CONTENT)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #443 

Updated to core 88 and storage 71.
The user's personal repos will now be read server-side to ensure that the private repos are included as well. 
Added unit tests.
Left puzzle for front-end.